### PR TITLE
feat: adicionar endpoint de pagamento via cartão (IMP-13)

### DIFF
--- a/src/controllers/pagamentosController.js
+++ b/src/controllers/pagamentosController.js
@@ -138,4 +138,84 @@ export const processarPagamentoBoleto = (req, res) => {
         },
     });
 };
-    
+
+export const processarPagamentoCartao = (req, res) => {
+    const { itens, cupom: codigoCupom, cartao } = req.body;
+
+    // PASSO 1: validar itens e dados do cartão
+    if (!itens || itens.length === 0) {
+        return res.status(400).json({ mensagem: 'Informe ao menos um item.' });
+    }
+    if (!cartao || !cartao.tipo) {
+        return res.status(400).json({ mensagem: 'Informe os dados do cartão (tipo: debito ou credito).' });
+    }
+    if (!['debito', 'credito'].includes(cartao.tipo)) {
+        return res.status(400).json({ mensagem: 'Tipo de cartão inválido. Use "debito" ou "credito".' });
+    }
+
+    // PASSO 2: buscar e validar produtos
+    const itensPedido = [];
+    for (const item of itens) {
+        const produto = produtos.find((p) => p.id === Number(item.produtoId));
+        if (!produto) {
+            return res.status(404).json({ mensagem: `Produto ${item.produtoId} não encontrado.` });
+        }
+        itensPedido.push({
+            produtoId: produto.id,
+            title: produto.title,
+            quantidade: Number(item.quantidade),
+            price: produto.price,
+        });
+    }
+
+    // PASSO 3: calcular subtotal
+    let subtotal = 0;
+    for (const item of itensPedido) {
+        subtotal += item.price * item.quantidade;
+    }
+
+    // PASSO 4: aplicar cupom se fornecido
+    let desconto = 0;
+    let cupomAplicado = null;
+    if (codigoCupom) {
+        const cupom = cupons.find((c) => c.codigo === codigoCupom && c.ativo);
+        if (!cupom) {
+            return res.status(400).json({ mensagem: 'Cupom inválido ou expirado.' });
+        }
+        desconto = cupom.tipo === '%' ? subtotal * (cupom.desconto / 100) : cupom.desconto;
+        cupomAplicado = cupom.codigo;
+    }
+
+    const total = Math.max(0, subtotal - desconto);
+    const parcelas = cartao.tipo === 'credito' ? (cartao.parcelas || 1) : 1;
+    const metodoPagamento = cartao.tipo === 'credito' ? 'cartao_credito' : 'cartao_debito';
+
+    // PASSO 5: montar o pedido e salvar
+    const novoPedido = {
+        id: pedidos.length + 1,
+        usuarioId: req.usuario.id,
+        data: new Date().toISOString(),
+        status: 'ativo',
+        metodoPagamento,
+        itens: itensPedido,
+        subtotal: parseFloat(subtotal.toFixed(2)),
+        desconto: parseFloat(desconto.toFixed(2)),
+        total: parseFloat(total.toFixed(2)),
+        cupom: cupomAplicado,
+        canceladoEm: null,
+    };
+    pedidos.push(novoPedido);
+
+    // PASSO 6: retornar 201 com dados do cartão mock
+    return res.status(201).json({
+        pedido: novoPedido,
+        pagamento: {
+            metodo: metodoPagamento,
+            bandeira: 'Visa',
+            ultimos4Digitos: '1234',
+            parcelas,
+            valorParcela: parseFloat((total / parcelas).toFixed(2)),
+            autorizacao: `AUTH-${Date.now()}`,
+        },
+    });
+};

--- a/src/routes/pagamentos.js
+++ b/src/routes/pagamentos.js
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { processarPagamentoPix, processarPagamentoBoleto } from '../controllers/pagamentosController.js';
+import { processarPagamentoPix, processarPagamentoBoleto, processarPagamentoCartao } from '../controllers/pagamentosController.js';
 import { autenticar } from '../middlewares/autenticar.js';
 
 const router = Router();
@@ -137,5 +137,91 @@ router.post('/pix', autenticar, processarPagamentoPix);
  *         description: Produto não encontrado.
  */
 router.post('/boleto', autenticar, processarPagamentoBoleto);
+
+/**
+ * @swagger
+ * /api/v1/pagamentos/cartao:
+ *   post:
+ *     summary: Processar pagamento via cartão
+ *     description: Cria um novo pedido com pagamento via cartão de débito ou crédito.
+ *     tags:
+ *       - Pagamentos
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - itens
+ *               - cartao
+ *             properties:
+ *               itens:
+ *                 type: array
+ *                 items:
+ *                   type: object
+ *                   properties:
+ *                     produtoId:
+ *                       type: integer
+ *                       example: 1
+ *                     quantidade:
+ *                       type: integer
+ *                       example: 2
+ *               cupom:
+ *                 type: string
+ *                 example: "BEMVINDO10"
+ *               cartao:
+ *                 type: object
+ *                 required:
+ *                   - tipo
+ *                 properties:
+ *                   tipo:
+ *                     type: string
+ *                     enum: [debito, credito]
+ *                     example: "credito"
+ *                   parcelas:
+ *                     type: integer
+ *                     example: 3
+ *     responses:
+ *       201:
+ *         description: Pedido criado com sucesso.
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 pedido:
+ *                   type: object
+ *                 pagamento:
+ *                   type: object
+ *                   properties:
+ *                     metodo:
+ *                       type: string
+ *                       example: "cartao_credito"
+ *                     bandeira:
+ *                       type: string
+ *                       example: "Visa"
+ *                     ultimos4Digitos:
+ *                       type: string
+ *                       example: "1234"
+ *                     parcelas:
+ *                       type: integer
+ *                       example: 3
+ *                     valorParcela:
+ *                       type: number
+ *                       example: 11.34
+ *                     autorizacao:
+ *                       type: string
+ *                       example: "AUTH-123456"
+ *       400:
+ *         description: Itens não informados, cartão inválido ou cupom inválido.
+ *       401:
+ *         description: Token ausente ou inválido.
+ *       404:
+ *         description: Produto não encontrado.
+ */
+router.post('/cartao', autenticar, processarPagamentoCartao);
 
 export default router;


### PR DESCRIPTION
## O que foi feito
- Adicionado endpoint `POST /api/v1/pagamentos/cartao`
- Suporta débito e crédito (campo `cartao.tipo`)
- Crédito permite parcelamento (campo `cartao.parcelas`)
- Valida itens, busca produtos, aplica cupom e retorna dados do cartão mock
- Documentação Swagger adicionada

## Como testar
1. `POST /api/v1/auth/login` para obter token
2. `POST /api/v1/pagamentos/cartao` com body:
```json
{
  "itens": [{ "produtoId": 1, "quantidade": 2 }],
  "cupom": "BEMVINDO10",
  "cartao": {
    "tipo": "credito",
    "parcelas": 3
  }
}