### PR TITLE
fix: alinhar campo image para img conforme US-05

### DIFF
--- a/src/controllers/carrinhoController.js
+++ b/src/controllers/carrinhoController.js
@@ -8,7 +8,7 @@ export const listarItens = (req, res) => {
         id:    item.produto_id,
         title: item.title,
         price: item.price,
-        image: item.image,
+        img: item.image,
         qty:   item.quantidade,
       }));
 


### PR DESCRIPTION
Correção do campo image para img no controller e na documentação Swagger do carrinho, alinhando com o padrão da US-05 e do frontend.

Arquivos alterados:
- src/controllers/carrinhoController.js
- src/routes/carrinho.js

Closes #29