### PR TITLE
fix(avaliacoes): corrige rota de avaliacoes e torna detalhe de produto publico

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -14,7 +14,6 @@ import pedidosRouter    from './routes/pedidos.js';
 import favoritosRouter  from './routes/favoritos.js';
 import usuariosRouter   from './routes/usuarios.js';
 import adminRouter      from './routes/admin.js';
-import avaliacoesRouter from './routes/avaliacoes.js';
 
 const app = express();
 app.use(express.json());
@@ -58,7 +57,6 @@ app.use('/api-docs',
 // Rotas
 app.use('/api/v1/auth',            authRouter);
 app.use('/api/v1/produtos',        produtosRouter);
-app.use('/api/v1/produtos',        avaliacoesRouter); // /:produtoId/avaliacoes
 app.use('/api/v1/categorias',      categoriasRouter);
 app.use('/api/v1/cupons',          cuponsRouter);
 app.use('/api/v1/lojas-parceiras', lojasRouter);

--- a/src/routes/produtos.js
+++ b/src/routes/produtos.js
@@ -10,12 +10,16 @@ import { validar }    from '../middlewares/validar.js';
 import {
     schemaCriarProduto, schemaEditarProduto
 } from '../validators/schemas.js';
+import avaliacoesRouter from './avaliacoes.js';
 
 const router = Router();
 
 // Rotas públicas
 router.get('/',    listarProdutos);
-router.get('/:id', autenticar, buscarProdutoPorId);
+router.get('/:id', buscarProdutoPorId);
+
+// Avaliações aninhadas em /:produtoId/avaliacoes
+router.use('/:produtoId/avaliacoes', avaliacoesRouter);
 
 // Rotas admin
 router.post('/',
@@ -28,8 +32,6 @@ router.patch('/:id/estoque',
     autenticar, autorizar('admin'), atualizarEstoque);
 router.delete('/:id',
     autenticar, autorizar('admin'), deletarProduto);
-
-export default router;
 
 /**
  * @openapi
@@ -146,6 +148,5 @@ export default router;
  *       '500':
  *         description: Erro interno do servidor.
  */
-
 
 export default router;


### PR DESCRIPTION
## Problemas corrigidos

- Rota de avaliacoes estava montada diretamente em `/api/v1/produtos`, fazendo com que GET e POST em `/:id/avaliacoes` nunca chegassem ao controller
- Movida para dentro do router de produtos via `router.use('/:produtoId/avaliacoes', avaliacoesRouter)`
- `GET /api/v1/produtos/:id` exigia autenticacao de forma inconsistente com a listagem publica; autenticacao removida