### PR TITLE
feat(admin): endpoint GET /admin/pedidos para listar todos os pedidos

### DIFF
--- a/src/controllers/adminController.js
+++ b/src/controllers/adminController.js
@@ -94,6 +94,54 @@ try {
 }
 };
 
+export const listarTodosPedidos = (req, res) => {
+try {
+    const { page = 1, limit = 20, status, usuario_id } = req.query;
+
+    let query  = 'SELECT * FROM pedidos WHERE 1=1';
+    const params = [];
+
+    if (status) {
+    query += ' AND status = ?';
+    params.push(status);
+    }
+
+    if (usuario_id) {
+    query += ' AND usuario_id = ?';
+    params.push(Number(usuario_id));
+    }
+
+    query += ' ORDER BY data DESC';
+
+    const todos  = db.prepare(query).all(...params).map((row) => ({
+    id:              row.id,
+    usuarioId:       row.usuario_id,
+    data:            row.data,
+    status:          row.status,
+    metodoPagamento: row.metodo_pagamento,
+    itens:           typeof row.itens === 'string' ? JSON.parse(row.itens) : (row.itens || []),
+    subtotal:        row.subtotal,
+    desconto:        row.desconto,
+    total:           row.total,
+    cupom:           row.cupom,
+    canceladoEm:     row.cancelado_em,
+    }));
+
+    const total      = todos.length;
+    const pg         = Math.max(1, parseInt(page));
+    const lim        = Math.min(100, Math.max(1, parseInt(limit)));
+    const inicio     = (pg - 1) * lim;
+
+    return res.status(200).json({
+    data: todos.slice(inicio, inicio + lim),
+    total, page: pg, limit: lim,
+    totalPages: Math.ceil(total / lim),
+    });
+} catch (e) {
+    return res.status(500).json({ erro: 'Erro ao listar pedidos.' });
+}
+};
+
 export const deletarUsuario = (req, res) => {
 try {
     const id = Number(req.params.id);

--- a/src/routes/admin.js
+++ b/src/routes/admin.js
@@ -2,6 +2,7 @@ import { Router } from 'express';
 import {
     dashboardAdmin, listarUsuarios,
     buscarUsuarioPorId, alterarPapelUsuario, deletarUsuario,
+    listarTodosPedidos,
 } from '../controllers/adminController.js';
 import { autenticar } from '../middlewares/autenticar.js';
 import { autorizar }  from '../middlewares/autorizar.js';
@@ -12,11 +13,10 @@ const router = Router();
 router.use(autenticar, autorizar('admin'));
 
 router.get('/dashboard',            dashboardAdmin);
+router.get('/pedidos',              listarTodosPedidos);
 router.get('/usuarios',             listarUsuarios);
 router.get('/usuarios/:id',         buscarUsuarioPorId);
 router.patch('/usuarios/:id/papel', alterarPapelUsuario);
 router.delete('/usuarios/:id',      deletarUsuario);
 
 export default router;
-
-//fazer swegger


### PR DESCRIPTION
## Nova funcionalidade

Adicionado `GET /api/v1/admin/pedidos` para que administradores possam visualizar todos os pedidos do sistema.

### Filtros opcionais via query string
- `?status=ativo|concluido|cancelado` — filtra por status
- `?usuario_id=123` — filtra por usuario
- `?page=1&limit=20` — paginacao (padrao: 20 por pagina, maximo 100)

### Resposta
```json
{
  "data": [...],
  "total": 7,
  "page": 1,
  "limit": 20,
  "totalPages": 1
}
```

Rota protegida: requer autenticacao + papel `admin`.