### PR TITLE
fix: remove export default duplicado em produtos.js

### DIFF
--- a/src/routes/produtos.js
+++ b/src/routes/produtos.js
@@ -339,6 +339,3 @@ export default router;
  *       '500':
  *         description: Erro interno do servidor.
  */
-
-
-export default router;


### PR DESCRIPTION
Remove o segundo export default router que ficou no final do arquivo após merges anteriores, causando SyntaxError na inicialização do servidor.