### PR TITLE
Chore/configurar cors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 JWT_SECRET=sua-chave-secreta-aqui
 JWT_EXPIRES_IN=2h
 PORT=3000
+CORS_ORIGIN=*

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+JWT_SECRET=sua-chave-secreta-aqui
+JWT_EXPIRES_IN=2h
+PORT=3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "bcryptjs": "^3.0.3",
         "better-sqlite3": "^12.10.0",
+        "cors": "^2.8.6",
         "dotenv": "^17.4.2",
         "express": "^4.18.2",
         "express-rate-limit": "^8.5.2",
@@ -431,6 +432,23 @@
       "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -631,6 +649,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1405,6 +1424,15 @@
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "bcryptjs": "^3.0.3",
     "better-sqlite3": "^12.10.0",
+    "cors": "^2.8.6",
     "dotenv": "^17.4.2",
     "express": "^4.18.2",
     "express-rate-limit": "^8.5.2",

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import express    from 'express';
+import cors       from 'cors';
 import rateLimit  from 'express-rate-limit';
 import swaggerJsDoc from 'swagger-jsdoc';
 import swaggerUi    from 'swagger-ui-express';
@@ -17,6 +18,11 @@ import adminRouter      from './routes/admin.js';
 import avaliacoesRouter from './routes/avaliacoes.js';
 
 const app = express();
+app.use(cors({
+  origin: process.env.CORS_ORIGIN || '*',
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
+}));
 app.use(express.json());
 
 // Rate limiting

--- a/src/config/auth.js
+++ b/src/config/auth.js
@@ -1,17 +1,6 @@
-// src/config/auth.js
-//
-// Configurações centralizadas de autenticação JWT.
-//
-// ⚠️ ATENÇÃO — boas práticas de segurança:
-//   Em produção, JWT_SECRET deve ser lido de uma variável de ambiente:
-//     export const JWT_SECRET = process.env.JWT_SECRET;
-//   Nunca commite uma chave secreta real em repositórios Git.
-//   O valor abaixo é exclusivamente para fins didáticos em ambiente local.
+if (!process.env.JWT_SECRET) {
+  throw new Error('JWT_SECRET não definido. Verifique o arquivo .env');
+}
 
-import 'dotenv/config';
-
-export const JWT_SECRET =
-    process.env.JWT_SECRET || 'bulbe-energia-segredo-dev-2026';
-
-export const JWT_EXPIRES_IN =
-    process.env.JWT_EXPIRES_IN || '2h';
+export const JWT_SECRET = process.env.JWT_SECRET;
+export const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '2h';


### PR DESCRIPTION
Adiciona o middleware `cors` para permitir que o frontend se comunique com a API.

- Instala o pacote `cors`
- Configura os métodos e headers permitidos
- Lê a origem permitida via variável de ambiente `CORS_ORIGIN` (padrão: `*`)
- Documenta `CORS_ORIGIN` no `.env.example`