### PR TITLE
feat(backend): adiciona campos price_was e promo nos produtos

### DIFF
--- a/src/controllers/produtosController.js
+++ b/src/controllers/produtosController.js
@@ -7,7 +7,7 @@ const parseProduto = (p) => {
   } catch {
     variations = [];
   }
-  return { ...p, variations };
+  return { ...p, variations, price_was: p.price_was ?? null, promo: p.promo ?? null };
 };
 
 export const listarProdutos = (req, res) => {

--- a/src/db/conexao.js
+++ b/src/db/conexao.js
@@ -138,4 +138,13 @@ if (!colunasPedidos.includes('itens')) {
   console.log('[DB] Migração aplicada: coluna "itens" adicionada à tabela pedidos.');
 }
 
+if (!colunasProdutos.includes('price_was')) {
+  db.exec('ALTER TABLE produtos ADD COLUMN price_was REAL;');
+  console.log('[DB] Migração: coluna "price_was" adicionada à tabela produtos.');
+}
+if (!colunasProdutos.includes('promo')) {
+  db.exec('ALTER TABLE produtos ADD COLUMN promo TEXT;');
+  console.log('[DB] Migração: coluna "promo" adicionada à tabela produtos.');
+}
+
 export default db;

--- a/src/db/seed.js
+++ b/src/db/seed.js
@@ -54,15 +54,15 @@ inserirLoja.run({ nome: 'Norte Baterias',          endereco: 'Rua do Comércio, 
 
 //  Produtos
 const inserirProduto = db.prepare(`
-  INSERT INTO produtos (title, description, price, category, stock, image, rating, variations, loja_id, destaque)
-  VALUES (@title, @description, @price, @category, @stock, @image, @rating, @variations, @loja_id, @destaque)
+  INSERT INTO produtos (title, description, price, price_was, promo, category, stock, image, rating, variations, loja_id, destaque)
+  VALUES (@title, @description, @price, @price_was, @promo, @category, @stock, @image, @rating, @variations, @loja_id, @destaque)
 `);
 
-inserirProduto.run({ title: 'Lâmpada LED 9W',              description: 'Lâmpada LED de alta eficiência energética, luz branca.',       price: 18.90,  category: 'Economia de energia', stock: 150, image: 'lampada-led-9w.jpg',                 rating: 4.5, variations: JSON.stringify(['Branca', 'Amarela', 'Neutra']),  loja_id: 1,    destaque: 1 });
-inserirProduto.run({ title: 'Liquidificador Mondial 1000W', description: 'Liquidificador de alta potência, ideal para smoothies.',        price: 183.00, category: 'Eletrônicos',         stock: 30,  image: 'liquidificador-mundial-1000w.jpg',   rating: 4.7, variations: JSON.stringify(['Preto', 'Prata']),               loja_id: null, destaque: 1 });
-inserirProduto.run({ title: 'Garrafa de água Tupperware',   description: 'Garrafa de água reutilizável, ideal para manter a hidratação.', price: 279.00, category: 'Conforto',            stock: 100, image: 'garrafa-tupperware.jpg',             rating: 4.3, variations: JSON.stringify(['500ml', '750ml', '1L']),         loja_id: null, destaque: 0 });
-inserirProduto.run({ title: 'Ventilador de mesa Britânia',  description: 'Ventilador de mesa com 3 velocidades e oscilação.',            price: 279.00, category: 'Eletrônicos',         stock: 15,  image: 'ventilador-mesa-britania.jpg',       rating: 4.2, variations: JSON.stringify(['Branco', 'Cinza', 'Prata']),    loja_id: 2,    destaque: 0 });
-inserirProduto.run({ title: 'Energia: Fique por dentro',    description: 'Livro sobre eficiência energética e energias renováveis.',     price: 45.90,  category: 'Educação',            stock: 60,  image: 'livro-energia-fique-por-dentro.jpg', rating: 4.0, variations: JSON.stringify(['Capa Dura', 'Brochura']),       loja_id: null, destaque: 1 });
+inserirProduto.run({ title: 'Lâmpada LED 9W',              description: 'Lâmpada LED de alta eficiência energética, luz branca.',       price: 18.90,  price_was: 24.90, promo: '10% OFF', category: 'Economia de energia', stock: 150, image: 'lampada-led-9w.jpg',                 rating: 4.5, variations: JSON.stringify(['Branca', 'Amarela', 'Neutra']),  loja_id: 1,    destaque: 1 });
+inserirProduto.run({ title: 'Liquidificador Mondial 1000W', description: 'Liquidificador de alta potência, ideal para smoothies.',        price: 183.00, price_was: 199.00, promo: '5% OFF', category: 'Eletrônicos',         stock: 30,  image: 'liquidificador-mundial-1000w.jpg',   rating: 4.7, variations: JSON.stringify(['Preto', 'Prata']),               loja_id: null, destaque: 1 });
+inserirProduto.run({ title: 'Garrafa de água Tupperware',   description: 'Garrafa de água reutilizável, ideal para manter a hidratação.', price: 279.00, price_was: 299.00, promo: '7% OFF', category: 'Conforto',            stock: 100, image: 'garrafa-tupperware.jpg',             rating: 4.3, variations: JSON.stringify(['500ml', '750ml', '1L']),         loja_id: null, destaque: 0 });
+inserirProduto.run({ title: 'Ventilador de mesa Britânia',  description: 'Ventilador de mesa com 3 velocidades e oscilação.',            price: 279.00, price_was: null, promo: null, category: 'Eletrônicos',         stock: 15,  image: 'ventilador-mesa-britania.jpg',       rating: 4.2, variations: JSON.stringify(['Branco', 'Cinza', 'Prata']),    loja_id: 2,    destaque: 0 });
+inserirProduto.run({ title: 'Energia: Fique por dentro',    description: 'Livro sobre eficiência energética e energias renováveis.',     price: 45.90,  price_was: null, promo: null, category: 'Educação',            stock: 60,  image: 'livro-energia-fique-por-dentro.jpg', rating: 4.0, variations: JSON.stringify(['Capa Dura', 'Brochura']),       loja_id: null, destaque: 1 });
 
 // Cupons 
 const inserirCupom = db.prepare(`


### PR DESCRIPTION
## O que foi feito
- Adicionada migração para coluna price_was (REAL) na tabela produtos
- Adicionada migração para coluna promo (TEXT) na tabela produtos
- Atualizado seed com valores reais de price_was e promo para cada produto
- Atualizada função parseProduto para incluir os novos campos na resposta da API

## Arquivos alterados
- src/db/conexao.js
- src/db/seed.js
- src/controllers/produtosController.js

## Como testar
1. Rodar npm run seed para recriar o banco com os novos campos
2. Rodar npm run dev para subir o servidor
3. Acessar http://localhost:3000/api/v1/produtos e verificar os campos price_was e promo em cada produto

## Observações
- Produtos sem preço anterior têm price_was: null
- Produtos sem promoção têm promo: null
- As migrações são seguras — verificam se a coluna já existe antes de criar